### PR TITLE
fix the bug of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ RUN cd /home && \
     conda install -c vacation hla-polysolver && \
     rm -r /home/hla-polysolver
 
+RUN apt-get update && apt-get install -y \
+    libncurses5 \
+    && apt-get clean && apt-get purge
+
 ENV CONDA_PREFIX /opt/conda
 
 WORKDIR /home


### PR DESCRIPTION
fix the lack of dependency libraries of samtools, such as "samtools: error while loading shared libraries: libncurses.so.5: cannot open shared object file: No such file or directory"